### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Build and Publish Docker Image
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/khaitranhq/pg-genrole/security/code-scanning/5](https://github.com/khaitranhq/pg-genrole/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with the repository contents (e.g., checking out the repository) and uses Docker-related actions. Therefore, the minimal permissions required are `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
